### PR TITLE
CSS: Implemented ValidateHsl() with more tests.

### DIFF
--- a/EditorExtensions/ExtensionMethods/StringExtensions.cs
+++ b/EditorExtensions/ExtensionMethods/StringExtensions.cs
@@ -1,0 +1,19 @@
+﻿using System;
+
+namespace MadsKristensen.EditorExtensions
+{
+    public static class StringExtensions
+    {
+        internal static bool ValidateNumericality(this string input)
+        {
+            foreach (char digit in input)
+            {
+                if (!Char.IsDigit(digit) && digit != '.')
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+    }
+}

--- a/EditorExtensions/Validation/CSS/Providers/ColorValuesInRangeErrorTagProvider.cs
+++ b/EditorExtensions/Validation/CSS/Providers/ColorValuesInRangeErrorTagProvider.cs
@@ -23,10 +23,10 @@ namespace MadsKristensen.EditorExtensions
             {
                 ValidateRgb(context, function);
             }
-            //else if (function.FunctionName.Text.StartsWith("hsl"))
-            //{
-            //    ValidateHsl(context, function);
-            //}
+            else if (function.FunctionName.Text.StartsWith("hsl"))
+            {
+                ValidateHsl(context, function);
+            }
 
             return ItemCheckResult.Continue;
         }
@@ -47,6 +47,61 @@ namespace MadsKristensen.EditorExtensions
                 else
                 {
                     ValidateAlphaValue(context, argument, text);
+                }
+            }
+        }
+
+        private static void ValidateHsl(ICssCheckerContext context, FunctionColor function)
+        {
+            ParseItem argument;
+            string text = "";
+            string[] pair;
+            int argumentCount = function.Arguments.Count;
+            int value;
+
+            if (function.FunctionName.Text.StartsWith("hsla") && argumentCount < 4)
+            {
+                context.AddError(new SimpleErrorTag(function.Arguments[2], "Validation: HSLA expects alpha value between 0 and 1 as fourth parameter", CssErrorFlags.TaskListWarning | CssErrorFlags.UnderlineRed));
+            }
+
+            for (int i = 0; i < argumentCount; i++)
+            {
+                argument = function.Arguments[i];
+                text = argument.Text.Trim(',');
+
+                if (i < 3)
+                {
+                    pair = text.Split('%');
+                    if (pair.Length > 1 || pair[0].ValidateNumericality())
+                    {
+                        context.AddError(new SimpleErrorTag(argument, "Validation: Invalid value", CssErrorFlags.TaskListWarning | CssErrorFlags.UnderlineRed));
+                    }
+
+                    if (!int.TryParse(pair[0], out value))
+                    {
+                        context.AddError(new SimpleErrorTag(argument, "Validation: Missing value", CssErrorFlags.TaskListWarning | CssErrorFlags.UnderlineRed));
+                    }
+
+                    else
+                    {
+                        if (value < 0 || value > 100)
+                        {
+                            context.AddError(new SimpleErrorTag(argument, "Validation: Values must be between 0 and 100%", CssErrorFlags.TaskListWarning | CssErrorFlags.UnderlineRed));
+                        }
+
+                        if (i > 0 && value > 0 && pair[1] == "%")
+                        {
+                            context.AddError(new SimpleErrorTag(argument, "Validation: Parameter missing the % unit", CssErrorFlags.TaskListWarning | CssErrorFlags.UnderlineRed));
+                        }
+                    }
+                }
+                else if (function.FunctionName.Text.StartsWith("hsla"))
+                {
+                    ValidateAlphaValue(context, argument, text);
+                }
+                else
+                {
+                    context.AddError(new SimpleErrorTag(argument, "Validation: HSL cannot have fourth parameter. Are you confusing HSL with HSLA?", CssErrorFlags.TaskListWarning | CssErrorFlags.UnderlineRed));
                 }
             }
         }

--- a/EditorExtensions/WebEssentials2013.csproj
+++ b/EditorExtensions/WebEssentials2013.csproj
@@ -337,6 +337,7 @@
     <Compile Include="Classifications\Markdown\MarkdownClassifier.cs" />
     <Compile Include="Classifications\Markdown\MarkdownContentTypeDefinition.cs" />
     <Compile Include="Classifications\CSS\ModernizrClassifier.cs" />
+    <Compile Include="ExtensionMethods\StringExtensions.cs" />
     <Compile Include="Helpers\Extensions.cs" />
     <Compile Include="MenuItems\AddIntellisenseFile.cs" />
     <Compile Include="Commands\Code\IntellisenseWriter.cs" />


### PR DESCRIPTION
- A more robust solution for ValidateHsl.
- HSL specs: [//w3.org/wiki/CSS3/Color/HSL](http://w3.org/wiki/CSS3/Color/HSL)
- HSLA specs: [//w3.org/wiki/CSS3/Color/HSLA](http://w3.org/wiki/CSS3/Color/HSLA)
